### PR TITLE
feat: add retry consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ export class UsersConsumer {
   })
   @UseFilters(
     new KafkaConsumerErrorTopicExceptionFilter({
-      topicPicker: (config: ConfigDto) => config.kafka.errorTopic,
+      errorTopicPicker: (config: ConfigDto) => config.kafka.errorTopic,
     }),
   )
   public async onMessage(): Promise<void> {

--- a/README.md
+++ b/README.md
@@ -531,6 +531,38 @@ export class UsersConsumer {
 
 </details>
 
+<details>
+<summary>3.3. <code>KafkaConsumerErrorTopicExceptionFilter</code> also support retry topic for retriable errors</summary>
+
+```typescript
+import {
+  KafkaConsumerErrorTopicExceptionFilter,
+  KafkaConsumerEventPattern,
+} from "@byndyusoft/nest-kafka";
+import { Controller, UseFilters } from "@nestjs/common";
+
+import { ConfigDto } from "~/src";
+
+@Controller()
+export class UsersConsumer {
+  @KafkaConsumerEventPattern({
+    topicPicker: (config: ConfigDto) => config.kafka.topic,
+    fromBeginning: true,
+  })
+  @UseFilters(
+    new KafkaConsumerErrorTopicExceptionFilter({
+      retryTopicPicker: (config: ConfigDto) => config.kafka.retryTopic,
+      errorTopicPicker: (config: ConfigDto) => config.kafka.errorTopic,
+    }),
+  )
+  public async onMessage(): Promise<void> {
+    throw new Error("some error");
+  }
+}
+```
+
+</details>
+
 ### Producing Messages
 
 </details>

--- a/src/consts/index.ts
+++ b/src/consts/index.ts
@@ -19,5 +19,6 @@ export * from "./defaultConnectionName";
 export * from "./kafkaBaseOptionsToken";
 export * from "./kafkaConsumerTransportId";
 export * from "./kafkaOptionsToken";
+export * from "./kafkaRetryConsumerTransportId";
 export * from "./producersMapToken";
 export * from "./schemaRegistriesMapToken";

--- a/src/consts/kafkaRetryConsumerTransportId.ts
+++ b/src/consts/kafkaRetryConsumerTransportId.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Byndyusoft
+ * Copyright 2023 Byndyusoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,6 @@
  * limitations under the License.
  */
 
-export * from "./decorators";
-export * from "./errors";
-export * from "./exceptions";
-export * from "./interceptors";
-export * from "./interfaces";
-export * from "./kafkaConsumer";
-export * from "./kafkaConsumerMessageHandler";
-export * from "./kafkaConsumerMessageHandlerLogger";
-export * from "./kafkaRetryConsumer";
-export * from "./retryStrategies";
+export const KafkaRetryConsumerTransportId = Symbol(
+  "KafkaRetryConsumerTransportId",
+);

--- a/src/consumer/decorators/index.ts
+++ b/src/consumer/decorators/index.ts
@@ -17,4 +17,5 @@
 export * from "./kafkaConsumerEventPatternDecorator";
 export * from "./kafkaHeadersDecorator";
 export * from "./kafkaKeyDecorator";
+export * from "./kafkaRetryConsumerEventPatternDecorator";
 export * from "./kafkaValueDecorator";

--- a/src/consumer/decorators/kafkaRetryConsumerEventPatternDecorator.ts
+++ b/src/consumer/decorators/kafkaRetryConsumerEventPatternDecorator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Byndyusoft
+ * Copyright 2023 Byndyusoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,19 @@
  * limitations under the License.
  */
 
-export * from "./decorators";
-export * from "./errors";
-export * from "./exceptions";
-export * from "./interceptors";
-export * from "./interfaces";
-export * from "./kafkaConsumer";
-export * from "./kafkaConsumerMessageHandler";
-export * from "./kafkaConsumerMessageHandlerLogger";
-export * from "./kafkaRetryConsumer";
-export * from "./retryStrategies";
+import crypto from "crypto";
+
+import { EventPattern } from "@nestjs/microservices";
+
+import { KafkaRetryConsumerTransportId } from "../../consts";
+import { IKafkaConsumerOptions } from "../interfaces";
+
+export function KafkaRetryConsumerEventPattern(
+  options: IKafkaConsumerOptions,
+): MethodDecorator {
+  return EventPattern(
+    crypto.randomUUID(), // we don't use this arg, but we can't leave it empty
+    KafkaRetryConsumerTransportId,
+    options,
+  );
+}

--- a/src/consumer/exceptions/kafkaConsumerErrorTopicExceptionFilter.ts
+++ b/src/consumer/exceptions/kafkaConsumerErrorTopicExceptionFilter.ts
@@ -113,7 +113,7 @@ export class KafkaConsumerErrorTopicExceptionFilter
   ): string | false {
     const topic =
       kafkaConsumerError.retriable &&
-      typeof this.options.retryTopicPicker === "function"
+      this.options.retryTopicPicker !== undefined
         ? this.options.retryTopicPicker
         : this.errorTopicPicker;
 

--- a/src/consumer/interfaces/kafkaConsumerErrorTopicExceptionFilterOptionsInterface.ts
+++ b/src/consumer/interfaces/kafkaConsumerErrorTopicExceptionFilterOptionsInterface.ts
@@ -19,12 +19,12 @@
 export interface IKafkaConsumerErrorTopicExceptionFilterOptions {
   readonly connectionName?: string;
 
-  readonly retryTopicPicker?: (...args: any[]) => string;
+  readonly retryTopicPicker?: ((...args: any[]) => string) | false;
 
-  readonly errorTopicPicker?: (...args: any[]) => string;
+  readonly errorTopicPicker?: ((...args: any[]) => string) | false;
 
   /**
    * @deprecated Use errorTopicPicker instead
    */
-  readonly topicPicker?: (...args: any[]) => string;
+  readonly topicPicker?: ((...args: any[]) => string) | false;
 }

--- a/src/consumer/interfaces/kafkaConsumerErrorTopicExceptionFilterOptionsInterface.ts
+++ b/src/consumer/interfaces/kafkaConsumerErrorTopicExceptionFilterOptionsInterface.ts
@@ -19,5 +19,10 @@
 export interface IKafkaConsumerErrorTopicExceptionFilterOptions {
   readonly connectionName?: string;
 
-  readonly topicPicker: (...args: any[]) => string;
+  readonly errorTopicPicker?: (...args: any[]) => string;
+
+  /**
+   * @deprecated Use errorTopicPicker instead
+   */
+  readonly topicPicker?: (...args: any[]) => string;
 }

--- a/src/consumer/interfaces/kafkaConsumerErrorTopicExceptionFilterOptionsInterface.ts
+++ b/src/consumer/interfaces/kafkaConsumerErrorTopicExceptionFilterOptionsInterface.ts
@@ -19,6 +19,8 @@
 export interface IKafkaConsumerErrorTopicExceptionFilterOptions {
   readonly connectionName?: string;
 
+  readonly retryTopicPicker?: (...args: any[]) => string;
+
   readonly errorTopicPicker?: (...args: any[]) => string;
 
   /**

--- a/src/consumer/interfaces/kafkaConsumerPayloadDecoderOptionsInterface.ts
+++ b/src/consumer/interfaces/kafkaConsumerPayloadDecoderOptionsInterface.ts
@@ -15,6 +15,8 @@
  */
 
 export interface IKafkaConsumerPayloadDecoderOptions {
+  readonly connectionName?: string;
+
   readonly key?: "string" | "json" | "schemaRegistry";
   readonly value?: "string" | "json" | "schemaRegistry";
   readonly headers?: "string";

--- a/src/consumer/kafkaRetryConsumer.ts
+++ b/src/consumer/kafkaRetryConsumer.ts
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2023 Byndyusoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import vm from "vm";
+
+import { Inject, Injectable } from "@nestjs/common";
+import {
+  CustomTransportStrategy,
+  MessageHandler,
+  Server,
+} from "@nestjs/microservices";
+import { Kafka } from "kafkajs";
+
+import {
+  DefaultConnectionName,
+  KafkaOptionsToken,
+  KafkaRetryConsumerTransportId,
+} from "../consts";
+import { IKafkaConnection, IKafkaOptions } from "../options";
+
+import { IKafkaConsumerOptions } from "./interfaces";
+import { KafkaConsumerMessageHandler } from "./kafkaConsumerMessageHandler";
+
+export interface IKafkaRetryConsumerRunOnceOptions {
+  readonly connectionName?: string;
+  readonly topic: string;
+  readonly messagesCount: number;
+}
+
+@Injectable()
+export class KafkaRetryConsumer
+  extends Server
+  implements CustomTransportStrategy
+{
+  public readonly transportId = KafkaRetryConsumerTransportId;
+
+  private readonly connectionOptionsMap: Map<string, IKafkaConnection>;
+
+  private readonly messageHandlersMap: Map<
+    string,
+    Map<string, MessageHandler>
+  > = new Map();
+
+  public constructor(
+    private readonly kafkaConsumerMessageHandler: KafkaConsumerMessageHandler,
+    @Inject(KafkaOptionsToken)
+    private readonly kafkaOptions: IKafkaOptions,
+  ) {
+    super();
+
+    this.connectionOptionsMap = new Map(
+      kafkaOptions.connections
+        .filter((x) => x.retryConsumer)
+        .map((x) => [x.name ?? DefaultConnectionName, x]),
+    );
+  }
+
+  public close(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public listen(callback: (error?: unknown) => void): void {
+    try {
+      this.init();
+      return callback();
+    } catch (error) {
+      return callback(error);
+    }
+  }
+
+  public async runOnce({
+    connectionName = DefaultConnectionName,
+    topic,
+    messagesCount: initialMessagesCount,
+  }: IKafkaRetryConsumerRunOnceOptions): Promise<void> {
+    if (initialMessagesCount <= 0) {
+      throw new Error("messagesCount must be greater than zero!");
+    }
+
+    const connectionOptions = this.getConnectionOptions(connectionName);
+
+    const {
+      messageHandler,
+      extras: { fromBeginning },
+    } = this.getMessageHandlerAndExtras(connectionName, topic);
+
+    const messagesCount = await this.calculateMessagesCount(
+      topic,
+      initialMessagesCount,
+      connectionOptions,
+    );
+
+    if (messagesCount === 0) {
+      return;
+    }
+
+    const retryConsumer = new Kafka(connectionOptions.cluster).consumer(
+      connectionOptions.retryConsumer!,
+    );
+
+    await retryConsumer.connect();
+
+    let processedMessagesCount = 0;
+
+    try {
+      await retryConsumer.subscribe({
+        topic,
+        fromBeginning,
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        retryConsumer
+          .run({
+            autoCommit: false,
+            eachMessage: async (rawPayload) => {
+              try {
+                await this.kafkaConsumerMessageHandler.handleMessage(
+                  connectionName,
+                  messageHandler,
+                  rawPayload,
+                );
+
+                await retryConsumer.commitOffsets([
+                  {
+                    topic,
+                    partition: rawPayload.partition,
+                    offset: (BigInt(rawPayload.message.offset) + 1n).toString(),
+                  },
+                ]);
+
+                processedMessagesCount++;
+
+                if (processedMessagesCount === messagesCount) {
+                  retryConsumer.pause([{ topic }]);
+                  resolve();
+                }
+              } catch (error) {
+                retryConsumer.pause([{ topic }]);
+                reject(error);
+              }
+            },
+          })
+          .catch(reject);
+      });
+    } finally {
+      await retryConsumer.disconnect();
+    }
+  }
+
+  private addMessageHandlerToMap(
+    connectionName: string,
+    topics: string[],
+    messageHandler: MessageHandler,
+  ): void {
+    if (!this.messageHandlersMap.has(connectionName)) {
+      this.messageHandlersMap.set(connectionName, new Map());
+    }
+
+    const connectionsMap = this.messageHandlersMap.get(connectionName)!;
+
+    for (const topic of topics) {
+      connectionsMap.set(topic, messageHandler);
+    }
+  }
+
+  private async calculateMessagesCount(
+    topic: string,
+    initialMessagesCount: number,
+    connectionOptions: IKafkaConnection,
+  ): Promise<number> {
+    let overallLag = 0n;
+
+    const admin = new Kafka(connectionOptions.cluster).admin();
+
+    await admin.connect();
+
+    try {
+      const [topicOffsets, [retryConsumerOffsets]] = await Promise.all([
+        admin.fetchTopicOffsets(topic),
+        admin.fetchOffsets({
+          groupId: connectionOptions.retryConsumer!.groupId,
+          topics: [topic],
+        }),
+      ]);
+
+      for (const topicPartitionOffset of topicOffsets) {
+        const retryConsumerPartitionOffset = BigInt(
+          retryConsumerOffsets.partitions.find(
+            (x) => x.partition === topicPartitionOffset.partition,
+          )?.offset ?? 0n,
+        );
+
+        overallLag +=
+          BigInt(topicPartitionOffset.high) -
+          (retryConsumerPartitionOffset < 0n
+            ? 0n
+            : retryConsumerPartitionOffset);
+      }
+    } finally {
+      await admin.disconnect();
+    }
+
+    return Math.min(initialMessagesCount, Number(overallLag));
+  }
+
+  private getConnectionOptions(connectionName: string): IKafkaConnection {
+    const connectionOptions = this.connectionOptionsMap.get(connectionName);
+
+    if (!connectionOptions) {
+      throw new Error(
+        `Connection options with name ${connectionName} doesn't exists!`,
+      );
+    }
+
+    return connectionOptions;
+  }
+
+  private getMessageHandlerAndExtras(
+    connectionName: string,
+    topic: string,
+  ): {
+    readonly messageHandler: MessageHandler;
+    readonly extras: IKafkaConsumerOptions;
+  } {
+    const messageHandler = this.messageHandlersMap
+      .get(connectionName)
+      ?.get(topic);
+
+    if (!messageHandler) {
+      throw new Error(
+        `messageHandler for connection name ${connectionName} and topic ${topic} doesn't exists!`,
+      );
+    }
+
+    return {
+      messageHandler,
+      extras: messageHandler.extras as IKafkaConsumerOptions,
+    };
+  }
+
+  private init(): void {
+    const vmContext = vm.createContext({
+      topicPickerArgs: this.kafkaOptions.topicPickerArgs,
+    });
+
+    for (const [, messageHandler] of this.getHandlers().entries()) {
+      const { connectionName = DefaultConnectionName, topicPicker } =
+        messageHandler.extras as IKafkaConsumerOptions;
+
+      const topics = [
+        vm.runInContext(
+          `(${topicPicker.toString()})(...topicPickerArgs)`,
+          vmContext,
+        ) as string | string[],
+      ].flat();
+
+      this.addMessageHandlerToMap(connectionName, topics, messageHandler);
+    }
+  }
+}

--- a/src/kafkaModule.ts
+++ b/src/kafkaModule.ts
@@ -35,6 +35,7 @@ import {
   KafkaConsumer,
   KafkaConsumerMessageHandler,
   KafkaConsumerMessageHandlerLogger,
+  KafkaRetryConsumer,
 } from "./consumer";
 import { IKafkaOptions } from "./options";
 import {
@@ -60,6 +61,7 @@ export class KafkaModule {
       KafkaCoreProducer,
       KafkaCoreSchemaRegistry,
       KafkaProducer,
+      KafkaRetryConsumer,
       KafkaSchemaRegistry,
       ...kafkaProducerDecoratedProviders.createProviders(),
       ...kafkaSchemaRegistryDecoratedProviders.createProviders(),

--- a/src/options/kafkaConnectionInterface.ts
+++ b/src/options/kafkaConnectionInterface.ts
@@ -25,6 +25,8 @@ export interface IKafkaConnection {
 
   readonly consumer?: ConsumerConfig;
 
+  readonly retryConsumer?: ConsumerConfig;
+
   readonly producer?: ProducerConfig;
 
   readonly schemaRegistry?: IKafkaSchemaRegistryConnection;


### PR DESCRIPTION
Добавил retry consumer. Основные отличия retry consumer от обычного:
- Retry consumer нужно стартовать вручную, указав ему топик и количество сообщений которое нужно обработать (больше сообщений чем есть в топике вычитывать не будет)
- Retry consumer останавливается после первого упавшего сообщения

Доработал KafkaConsumerErrorTopicExceptionFilter:
- Переименовал topicPicker в errorTopicPicker (с сохранением обратной совместимости)
- Добавил в него поддержку retry топика
- Добавил возможность "выключить" какой-нибудь топик, чтобы например бесконечно не складывать retry сообщения в свой-же retry топик (или бесконечно не отправлять их в error топик)

Также доработал KafkaConsumerPayloadDecoder:
- Добавил поддержку connectionName