### PR TITLE
Next

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,7 @@ export class UsersRetryConsumer {
     new KafkaConsumerErrorTopicExceptionFilter({
       retryTopicPicker: false,
       errorTopicPicker: (config: ConfigDto) => config.kafka.errorTopic,
+      resendHeadersPrefix: "retry",
     }),
   )
   public async onMessage(): Promise<void> {

--- a/src/consumer/exceptions/kafkaConsumerErrorTopicExceptionFilter.ts
+++ b/src/consumer/exceptions/kafkaConsumerErrorTopicExceptionFilter.ts
@@ -151,6 +151,7 @@ export class KafkaConsumerErrorTopicExceptionFilter
             originalPartition: String(payload.rawPayload.partition),
             originalOffset: payload.rawPayload.message.offset,
             originalTimestamp: payload.rawPayload.message.timestamp,
+            originalTraceId: context.traceId,
             error: JSON.stringify(serializeError(cause)),
           },
         },

--- a/src/consumer/interfaces/kafkaConsumerContextInterface.ts
+++ b/src/consumer/interfaces/kafkaConsumerContextInterface.ts
@@ -29,4 +29,5 @@ export interface IKafkaConsumerContext {
   readonly kafkaConsumerMessageHandlerLogger: KafkaConsumerMessageHandlerLogger;
 
   readonly isFinalAttempt: boolean;
+  readonly traceId: string;
 }

--- a/src/consumer/interfaces/kafkaConsumerErrorTopicExceptionFilterOptionsInterface.ts
+++ b/src/consumer/interfaces/kafkaConsumerErrorTopicExceptionFilterOptionsInterface.ts
@@ -27,4 +27,9 @@ export interface IKafkaConsumerErrorTopicExceptionFilterOptions {
    * @deprecated Use errorTopicPicker instead
    */
   readonly topicPicker?: ((...args: any[]) => string) | false;
+
+  /**
+   * @default "original"
+   */
+  readonly resendHeadersPrefix?: string;
 }

--- a/src/consumer/kafkaConsumerMessageHandler.ts
+++ b/src/consumer/kafkaConsumerMessageHandler.ts
@@ -167,6 +167,7 @@ export class KafkaConsumerMessageHandler {
         kafkaConsumerMessageHandlerLogger:
           this.kafkaConsumerMessageHandlerLogger,
         isFinalAttempt,
+        traceId: rootSpan.context().toTraceId(),
       };
 
       const resultOrStream = await messageHandler(payload, context);


### PR DESCRIPTION
- Добавил ID трассы в заголовок при пересылке сообщения в retry/error топик, чтобы быстро находить ее в Jaeger
- Добавил возможность сменить префикс для заголовков при пересылке сообщений в retry/error топик, чтобы при пересылке сообщений из retry топика в error можно было сохранить заголовки оригинального топика