### PR TITLE
feat: added create span trace for send and sendBatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ import { ConfigDto } from "./config";
           },
         ],
         topicPickerArgs: [config],
+        // You can set business keys from the message you are sending that will be included in the tracing
+        traceMessageKeys: ["businessKey1", "businessKey2"],
       }),
     }),
     // ...
@@ -255,6 +257,8 @@ import { ConfigDto } from "./config";
           },
         ],
         topicPickerArgs: [config],
+        // You can set business keys from the message you are sending that will be included in the tracing
+        traceMessageKeys: ["businessKey1", "businessKey2"],
       }),
     }),
     // ...
@@ -295,6 +299,8 @@ import { ConfigDto } from "./config";
           },
         ],
         topicPickerArgs: [config],
+        // You can set business keys from the message you are sending that will be included in the tracing
+        traceMessageKeys: ["businessKey1", "businessKey2"],
       }),
     }),
     // ...

--- a/src/options/kafkaOptionsInterface.ts
+++ b/src/options/kafkaOptionsInterface.ts
@@ -26,4 +26,6 @@ export interface IKafkaOptions {
   readonly topicPickerArgs: any[];
 
   readonly consumerRetryOptions?: WrapOptions;
+
+  readonly traceMessageKeys?: string[];
 }

--- a/src/schemaRegistry/kafkaSchemaRegistry.ts
+++ b/src/schemaRegistry/kafkaSchemaRegistry.ts
@@ -57,12 +57,14 @@ export class KafkaSchemaRegistry implements IDecoratedProvider {
   public encode(
     ...args: Parameters<SchemaRegistry["encode"]>
   ): ReturnType<SchemaRegistry["encode"]> {
-    const span = this.tracingService.getRootSpan();
-    const [, payload] = args as [number, Record<string, unknown>];
+    if (this.kafkaOptions.traceMessageKeys) {
+      const span = this.tracingService.getRootSpan();
+      const [, payload] = args as [number, Record<string, unknown>];
 
-    for (const key of this.kafkaOptions.traceMessageKeys!) {
-      if (key in payload) {
-        span.setTag(key, payload[key]);
+      for (const key of this.kafkaOptions.traceMessageKeys) {
+        if (key in payload) {
+          span.setTag(key, payload[key]);
+        }
       }
     }
 


### PR DESCRIPTION
В ПР две фичи:
1. создает спан с информацией об отправленном сообщении в кафку (ключ сообщения, базовый offset, партицию и имя канала)
2. добавляет в корневой спан указанные в конфиге (опция traceMessageKeys) бизнес ключи из отправляемого сообщения 